### PR TITLE
Fix detection of view doc string

### DIFF
--- a/apifairy/core.py
+++ b/apifairy/core.py
@@ -224,7 +224,7 @@ class APIFairy:
                 if tag:
                     operation['tags'] = [tag]
                 docs = (view_func.__doc__ or '').strip().split('\n')
-                if docs:
+                if docs[0]:
                     operation['summary'] = docs[0]
                 if len(docs) > 1:
                     operation['description'] = '\n'.join(docs[1:]).strip()

--- a/tests/test_apifairy.py
+++ b/tests/test_apifairy.py
@@ -292,3 +292,19 @@ class TestAPIFairy(unittest.TestCase):
         assert 'SchemaUpdate' in apispec['components']['schemas']
         assert 'Schema2List' in apispec['components']['schemas']
         assert 'Foo' in apispec['components']['schemas']
+
+    def test_apispec_path_summary_from_docs(self):
+        app, apifairy = self.create_app()
+
+        @app.route('/users')
+        @response(Schema)
+        def get_users():
+            "Get Users."
+            pass
+
+        client = app.test_client()
+
+        rv = client.get('/apispec.json')
+        assert rv.status_code == 200
+        validate_spec(rv.json)
+        assert rv.json['paths']['/users']['get']['summary'] == 'Get Users.'


### PR DESCRIPTION
`(view_func.__doc__ or '').strip().split('\n')` will be `['']` when there isn't doc string exists, then `bool([''])` will return `True`.