### PR TITLE
Improve the order of path arguments

### DIFF
--- a/apifairy/core.py
+++ b/apifairy/core.py
@@ -270,18 +270,21 @@ class APIFairy:
             if path_arguments:
                 arguments = []
                 for _, type, name in path_arguments:
-                    arguments = {
+                    argument = {
                         'in': 'path',
                         'name': name,
                     }
                     if type == 'int:':
-                        arguments['schema'] = {'type': 'integer'}
+                        argument['schema'] = {'type': 'integer'}
                     elif type == 'float:':
-                        arguments['schema'] = {'type': 'number'}
+                        argument['schema'] = {'type': 'number'}
                     else:
-                        arguments['schema'] = {'type': 'string'}
-                    for method, operation in operations.items():
-                        operation['parameters'].insert(0, arguments)
+                        argument['schema'] = {'type': 'string'}
+                    arguments.append(argument)
+
+                for method, operation in operations.items():
+                    operation['parameters'] = arguments + \
+                        operation['parameters']
 
             path = re.sub(r'<([^<:]+:)?', '{', rule.rule).replace('>', '}')
             if path not in paths:

--- a/tests/test_apifairy.py
+++ b/tests/test_apifairy.py
@@ -348,9 +348,9 @@ class TestAPIFairy(unittest.TestCase):
         assert rv.json['paths']['/integers/{some_integer}'][
             'put']['parameters'][0]['schema']['type'] == 'integer'
         assert rv.json['paths']['/users/{user_id}/articles/{article_id}'][
-            'get']['parameters'][0]['name'] == 'article_id'
+            'get']['parameters'][0]['name'] == 'user_id'
         assert rv.json['paths']['/users/{user_id}/articles/{article_id}'][
-            'get']['parameters'][1]['name'] == 'user_id'
+            'get']['parameters'][1]['name'] == 'article_id'
 
     def test_path_arguments_detection(self):
         app, apifairy = self.create_app()
@@ -397,8 +397,38 @@ class TestAPIFairy(unittest.TestCase):
         assert '/foo/{bar}/{baz}' in rv.json['paths']
         assert '/{foo}/{bar}/{baz}' in rv.json['paths']
         assert rv.json['paths']['/{foo}/{bar}/{baz}']['get'][
-            'parameters'][0]['schema']['type'] == 'number'
+            'parameters'][0]['schema']['type'] == 'integer'
         assert rv.json['paths']['/{foo}/{bar}/{baz}']['get'][
             'parameters'][1]['schema']['type'] == 'string'
         assert rv.json['paths']['/{foo}/{bar}/{baz}']['get'][
-            'parameters'][2]['schema']['type'] == 'integer'
+            'parameters'][2]['schema']['type'] == 'number'
+
+    def test_path_arguments_order(self):
+        app, apifairy = self.create_app()
+
+        @app.route('/<foo>')
+        @arguments(QuerySchema)
+        @response(Schema)
+        def path_and_query():
+            pass
+
+        @app.route('/<foo>/<bar>')
+        @response(Schema)
+        def two_path_variables():
+            pass
+
+        client = app.test_client()
+
+        rv = client.get('/apispec.json')
+        assert rv.status_code == 200
+        validate_spec(rv.json)
+        assert '/{foo}' in rv.json['paths']
+        assert '/{foo}/{bar}' in rv.json['paths']
+        assert rv.json['paths']['/{foo}']['get'][
+            'parameters'][0]['name'] == 'foo'
+        assert rv.json['paths']['/{foo}']['get'][
+            'parameters'][1]['name'] == 'id'
+        assert rv.json['paths']['/{foo}/{bar}']['get'][
+            'parameters'][0]['name'] == 'foo'
+        assert rv.json['paths']['/{foo}/{bar}']['get'][
+            'parameters'][1]['name'] == 'bar'


### PR DESCRIPTION
I have submitted a PR for multiple arguments registration (https://github.com/miguelgrinberg/APIFairy/pull/11). However, after reviewing this part of the code, I realize the `arguments` list above is never used. I guess you may want to append all `argument` dict (typed to `arguments` ) into the `arguments` list, then put it in the parameters list.

With this PR, the items in the parameters list will be in proper order.