### PR TITLE
Fix adding query into spec parameters

### DIFF
--- a/apifairy/core.py
+++ b/apifairy/core.py
@@ -218,7 +218,7 @@ class APIFairy:
                     'parameters': [
                         {'in': location, 'schema': schema}
                         for schema, location in view_func._spec.get('args', [])
-                        if location != 'body'
+                        if location == 'query'
                     ],
                 }
                 if tag:


### PR DESCRIPTION
The origin judgment `if location != 'body'` looks like a typo of `if location != 'json'` since there isn't a `body` location passed anywhere. Considering the `arguments` supports used multiple times and set a different location other than `query`, I think it would be better to change it to `if location == 'query'`. Just ping me if you think the tests are needed for this change.