### PR TITLE
Fix typo in exception message

### DIFF
--- a/apifairy/core.py
+++ b/apifairy/core.py
@@ -161,7 +161,7 @@ class APIFairy:
                     elif isinstance(auth, HTTPTokenAuth):
                         name = 'api_key'
                     else:
-                        raise RuntimeError('Uknown authentication scheme')
+                        raise RuntimeError('Unknown authentication scheme')
                     if name in auth_names:
                         v = 2
                         new_name = f'{name}_{v}'


### PR DESCRIPTION
Just a minor fix.

By the way, I'm confused with [this test](https://github.com/miguelgrinberg/APIFairy/blob/master/tests/test_apifairy.py#L131-L172). The `baz` function defined a response with 201 status code (`@response(..., status_code=201)`), then why returning `({'name': 'foo'},)` will make the status code of the response become 200? It looks like a bug but nobody will write a test for a bug... I definitely missed something here.

Here is a minimal example:

```py
def test_response(app, client):

    @app.route('/foo')
    @response(FooSchema, status_code=201)
    def foo():
        return {'name': 'foo'}

    @app.route('/baz')
    @response(FooSchema, status_code=201)  # set the status code to 201
    def baz():
        return ({'name': 'baz'},)

    rv = client.get('/foo')
    assert rv.status_code == 201

    rv = client.get('/baz')
    assert rv.status_code == 200  # now the status code become 200
```