### PR TITLE
Update schema name resolver to remove unnecessary "List" suffix

### DIFF
--- a/apifairy/core.py
+++ b/apifairy/core.py
@@ -89,9 +89,7 @@ class APIFairy:
             name = schema.__class__.__name__
             if name.endswith("Schema"):
                 name = name[:-6] or name
-            if schema.many:
-                name += 'List'
-            elif schema.partial:
+            if schema.partial:
                 name += 'Update'
             return name
 

--- a/tests/test_apifairy.py
+++ b/tests/test_apifairy.py
@@ -290,7 +290,7 @@ class TestAPIFairy(unittest.TestCase):
             apispec = apifairy.apispec
         assert len(apispec['components']['schemas']) == 3
         assert 'SchemaUpdate' in apispec['components']['schemas']
-        assert 'Schema2List' in apispec['components']['schemas']
+        assert 'Schema2' in apispec['components']['schemas']
         assert 'Foo' in apispec['components']['schemas']
 
     def test_apispec_path_summary_from_docs(self):


### PR DESCRIPTION
In my opinion, the `List` suffix for the OpenAPI schema name is unnecessary.

Assuming we have a `User` schema. In OpenAPI, an array of `User` objects will be represented with:

```
type: array
items:
  $ref: '#/components/schemas/UserList'
```

Thus, the `UserList` schema is actually just a `User` schema. There won't be a conflict between `User` and `User(many=True)`.

Besides, there is only one schema called `UserList` generated in spec (not a `User` schema plus a `UserList` schema), the user may be confused with this behavior.