### PR TITLE
Headers autodocumentation

### DIFF
--- a/docs/decorators.rst
+++ b/docs/decorators.rst
@@ -243,3 +243,47 @@ If the roles feature of Flask-HTTPAuth is used, the documentation will include
 the required role(s) for each endpoint. Any keyword arguments given to the
 ``authenticate`` decorator, including the ``role`` argument, are passed
 through to Flask-HTTPAuth.
+
+@headers
+----------
+
+The ``headers`` decorator specifies input HTTP headers. The only argument
+this decorator requires is the schema definition for the headers,
+which can be given as a schema class or instance::
+
+    from apifairy import headers
+
+    class IdHeadersSchema(ma.Schema):
+       context_id = ma.Str(missing=None, required=True)
+       correlation_id = ma.Str(missing=None)
+
+
+    @app.route('/users', methods=['POST'])
+    @headers(IdHeadersSchema)
+    @body(UserSchema)
+    @response(UserSchema, status_code=201, description='A user was created.')
+    def create_user(id_headers: dict, user):
+        print(id_headers['context_id'])
+        # ...
+
+
+The decorator will deserialize and validate the input data and will only
+invoke the view function when the arguments are valid. In the case of a
+validation error, the error handler is invoked to generate an error response
+to the client.
+
+The deserialized input data is passed to the view function as a positional
+argument. When multiple input decorators are used (e.g. headers and body),
+the positional arguments are given in the same order as the decorators.
+
+Optionally, you can pass the headers as kwargs to the view function
+by setting ``as_kwargs`` to True in the decorator::
+
+
+    @app.route('/users', methods=['POST'])
+    @headers(IdHeadersSchema, as_kwargs=True)
+    @body(UserSchema)
+    @response(UserSchema, status_code=201, description='A user was created.')
+    def create_user(user, **kwargs):
+        print(kwargs['context_id'])
+        # ...

--- a/docs/decorators.rst
+++ b/docs/decorators.rst
@@ -254,7 +254,7 @@ which can be given as a schema class or instance::
     from apifairy import headers
 
     class IdHeadersSchema(ma.Schema):
-       context_id = ma.Str(missing=None, required=True)
+       context_id = ma.Str(required=True)
        correlation_id = ma.Str(missing=None)
 
 

--- a/src/apifairy/__init__.py
+++ b/src/apifairy/__init__.py
@@ -1,4 +1,4 @@
 from .core import APIFairy  # noqa: F401
 from .decorators import authenticate, arguments, body, response, \
-    other_responses  # noqa: F401
+    other_responses, headers  # noqa: F401
 from .fields import FileField  # noqa: F401

--- a/src/apifairy/core.py
+++ b/src/apifairy/core.py
@@ -235,7 +235,9 @@ class APIFairy:
                     'operationId': operation_id,
                     'parameters': [
                         {'in': location, 'schema': schema}
-                        for schema, location in view_func._spec.get('args', [])
+                        for schema, location
+                        in [*view_func._spec.get('args', []),
+                            *view_func._spec.get('headers', [])]
                         if location != 'body'
                     ],
                 }

--- a/src/apifairy/decorators.py
+++ b/src/apifairy/decorators.py
@@ -79,6 +79,19 @@ def body(schema, location='json', **kwargs):
     return decorator
 
 
+def headers(schema, location='headers', **kwargs):
+    if isinstance(schema, type):
+        schema = schema()
+
+    def decorator(f):
+        f = _ensure_sync(f)
+        if not hasattr(f, '_spec') or f._spec.get('headers') is None:
+            _annotate(f, headers=[])
+        f._spec['headers'].append((schema, location))
+        return use_args(schema, location=location, **kwargs)(f)
+    return decorator
+
+
 def response(schema, status_code=200, description=None):
     if isinstance(schema, type):  # pragma: no cover
         schema = schema()


### PR DESCRIPTION
Hello there!

I've started using APIFairy today in one of my projects and so far it's been great and comfortably easy to get into. One feature is missing for me though - the ability to autodocument HTTP headers on an endpoint similarly as APIFairy already allows for query args or json bodies. This would be useful for use cases like the [Prefer header](https://www.rfc-editor.org/rfc/rfc7240.html), passing tracing IDs across microservices and similar.

Therefore, I gave it a try to implement it in a PR. Documentation and tests are included, let me know if anything is missing.

Example usage:
```python
from apifairy import headers, body, response

class IdHeadersSchema(ma.Schema):
    context_id = ma.Str(required=True)
    correlation_id = ma.Str(missing=None)


@app.route('/users', methods=['POST'])
@headers(IdHeadersSchema)
@body(UserSchema)
@response(UserSchema, status_code=201, description='A user was created.')
def create_user(id_headers: dict, user):
    print(id_headers['context_id'])
    # ...
```