### PR TITLE
Update Swagger UI template

### DIFF
--- a/src/apifairy/templates/apifairy/swagger_ui.html
+++ b/src/apifairy/templates/apifairy/swagger_ui.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <title>{{ title }} {{ version }}</title>
-    <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@3//swagger-ui.css" >
+    <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist/swagger-ui.css" >
     <style>
       html
       {
@@ -30,8 +30,8 @@
   <body>
     <div id="swagger-ui"></div>
 
-    <script src="https://unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
-    <script src="https://unpkg.com/swagger-ui-dist@3/swagger-ui-standalone-preset.js"></script>
+    <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js"></script>
+    <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-standalone-preset.js"></script>
     <script>
       window.onload = function() {
       const ui = SwaggerUIBundle({


### PR DESCRIPTION
Remove version tag in resource link to load the latest version of Swagger UI.